### PR TITLE
Fix for V8 disables optimization for dispatch

### DIFF
--- a/src/Signal.js
+++ b/src/Signal.js
@@ -202,9 +202,13 @@
             if (! this.active) {
                 return;
             }
+            
+            var paramsArr = [];
+            for (var i=0; i < arguments.length; i++) {
+                paramsArr.push(arguments[i]);
+            }
 
-            var paramsArr = Array.prototype.slice.call(arguments),
-                n = this._bindings.length,
+            var n = this._bindings.length,
                 bindings;
 
             if (this.memorize) {


### PR DESCRIPTION
I posted this issue on the master (https://github.com/millermedeiros/js-signals/issues/67) but submitting a PR here because I can build and test this version.

I haven't checked the actual performance impact of this change vs. previous but suspect enabling optimization is better.
